### PR TITLE
Added client.buildjobs.artifacts

### DIFF
--- a/appveyor_client/client.py
+++ b/appveyor_client/client.py
@@ -1094,8 +1094,8 @@ class Deployments(_Base):
 
 class BuildJobs(_Base):
     """
-    Appveyor deployment api methods.
-
+    Appveyor build jobs api methods.
+    
     https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
     """
 
@@ -1116,10 +1116,17 @@ class BuildJobs(_Base):
                     "created": "2019-05-21T17:19:46.2713142+00:00"
                 }
             ]
-        Get artifacts.
+        Get the list of artifacts.
 
-        https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
         """
         method_url = 'GET /api/buildjobs/{job_id}/artifacts'
         method_url = method_url.format(job_id=job_id)
-        return self._client._request(method_url)   
+        return self._client._request(method_url)     
+
+    def artifact_url(self, job_id, file_name):
+        """
+        Returns the download URL of the artifact without downloading it
+        """
+        url = '/api/buildjobs/{job_id}/artifacts/{file_name}'
+        url = url.format(job_id=job_id, file_name=file_name)
+        return self._client._make_url(url)

--- a/appveyor_client/client.py
+++ b/appveyor_client/client.py
@@ -48,6 +48,7 @@ class AppveyorClient(object):
         self.roles = Roles(self)
         self.projects = Projects(self)
         self.builds = Builds(self)
+        self.buildjobs = BuildJobs(self)
         self.environments = Environments(self)
         self.deployments = Deployments(self)
 
@@ -1090,3 +1091,35 @@ class Deployments(_Base):
         data = {"deploymentId": deployment_id}
         body = json.dumps(data)
         return self._client._request(method_url, body=body)
+
+class BuildJobs(_Base):
+    """
+    Appveyor deployment api methods.
+
+    https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
+    """
+
+    def artifacts(self, job_id):
+        """
+        ::
+            [
+                {
+                    "fileName": "foo/bar/64/win.xpl",
+                    "type": "File",
+                    "size": 594944,
+                    "created": "2019-05-21T17:19:45.2243502+00:00"
+                },
+                {
+                    "fileName": "foo/bar/win.xpl",
+                    "type": "File",
+                    "size": 465920,
+                    "created": "2019-05-21T17:19:46.2713142+00:00"
+                }
+            ]
+        Get artifacts.
+
+        https://www.appveyor.com/docs/api/samples/download-artifacts-ps/
+        """
+        method_url = 'GET /api/buildjobs/{job_id}/artifacts'
+        method_url = method_url.format(job_id=job_id)
+        return self._client._request(method_url)   


### PR DESCRIPTION
Hi,
I added the API for getting the artifacts info for a job id.

The usage is 
```python

client.buildjobs.artifacts(job_id)`:

client.buildjobs.artifact_url(job_id, file_name)
```

```python
for job in build['jobs']:
    job_id = job['jobId']
    print("Artifacts for job {}: ".format(job_id))
    
    artifacts = client.buildjobs.artifacts(job_id)
    
    for artifact in artifacts:
        file_name = artifact['fileName']
        file_url = client.buildjobs.artifact_url(job_id, file_name)
        
        print("{file_name}: {file_url}".format(file_name=file_name, file_url=file_url))
```
fix #14 